### PR TITLE
Rework frame colors

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -19,6 +19,7 @@ pub struct Sample {
 pub enum SampleKind {
     Exec,
     Thread,
+    Other,
 }
 
 impl PartialEq for Sample {
@@ -40,7 +41,7 @@ impl Sample {
     where
         T: Read + Seek,
     {
-        let mut result = Self::new("root".to_string());
+        let mut result = Self::root();
         ExecutionSample::visit_events(input, |e| result.add_sample(&e, include_native, threads))?;
 
         Ok(result)
@@ -73,6 +74,15 @@ impl Sample {
             .unwrap_or_else(|| sample.thread.java_thread_id.to_string());
         let (idx, _) = self.children.insert_full(Self::new_thread(thread_name));
         return self.children.get_index_mut2(idx).unwrap();
+    }
+
+    fn root() -> Self {
+        Self {
+            name: "root".to_string(),
+            value: Default::default(),
+            children: Default::default(),
+            kind: SampleKind::Other,
+        }
     }
 
     fn new(name: String) -> Self {

--- a/web-src/colors.ts
+++ b/web-src/colors.ts
@@ -1,0 +1,9 @@
+// See https://coolors.co/user/palettes/6778041fba6e95000b08d65d
+export const palette = {
+  exec: "#F7B267",
+  other: "#F25C54",
+};
+
+export function pick_color(data: any): string {
+  return data.kind === "Exec" ? palette.exec : palette.other;
+}

--- a/web-src/index.ts
+++ b/web-src/index.ts
@@ -1,6 +1,7 @@
 import init, { parse } from "../pkg/jfrview";
 import * as fg from "d3-flame-graph";
 import { select } from "d3-selection";
+import { pick_color } from "./colors";
 
 const btn = configureEl("fileBtn", (input) => {
   const el = document.createElement("input");
@@ -56,8 +57,8 @@ async function refresh_graph() {
     .flamegraph()
     .width(960)
     .minFrameSize(1)
-    .setColorMapper((data, orig) => {
-      return data.data.kind === "Thread" ? "#ff0000" : orig;
+    .setColorMapper((data, _) => {
+      return pick_color(data.data);
     })
     .onHover((d) => {
       details.innerText = `${d.data.name} (${d.data.value} samples)`;

--- a/web-src/index.ts
+++ b/web-src/index.ts
@@ -27,6 +27,8 @@ configureEl("chart", (el) => {
 
 let activeBytes: Uint8Array | null = null;
 
+configureHmr();
+
 function fileSelected(data: File) {
   const fr = new FileReader();
   fr.onloadend = (e) => {
@@ -79,6 +81,21 @@ function refreshGraphOnChange(id: string): HTMLInputElement {
   });
 }
 
+/**
+ * Restore the current state of the flamegraph after hot module reload
+ */
+function configureHmr() {
+  if (module.hot) {
+    module.hot.dispose((data: any) => {
+      data.activeBytes = activeBytes;
+    });
+    module.hot.accept((_: any) => {
+      activeBytes = module.hot.data.activeBytes;
+      refresh_graph();
+    });
+  }
+}
+
 interface Data {
   /**
    * The payload
@@ -88,6 +105,10 @@ interface Data {
     readonly value: number;
   };
 }
+
+declare const module: {
+  hot: any;
+};
 
 declare module "d3-flame-graph" {
   interface FlameGraph {


### PR DESCRIPTION
Introduce predictable, semantic colors.
Previously, colors were determined via the hash of frame names. While this is reproducible, it is not obvious to the user what this means.

To keep this viewer simple, we opt to select one color for Exec Frames and one color for all other frames.
We may introduce other colors and new meanings in the future.